### PR TITLE
[fixed #167421371]終了間近のタスクを作成ユーザ宛てにメール通知してみましょう

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,10 @@ GEM
       kaminari (>= 0.13.0)
       rails
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -416,6 +420,7 @@ DEPENDENCIES
   jquery-rails
   kaminari (>= 1.0.1)
   kaminari-bootstrap
+  letter_opener
   listen (>= 3.0.5, < 3.2)
   momentjs-rails
   pg

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -8,4 +8,14 @@ module TasksHelper
       link_to "#{task.title}の期限は超過しています。期日:#{task.deadline}", group_task_path(group, task)
     end
   end
+
+  def task_reminder(task)
+    if task.deadline > Time.zone.today
+      "#{task.title}の期限は明日です。期日:#{task.deadline}"
+    elsif task.deadline == Time.zone.today
+      "#{task.title}の期限は本日です。期日:#{task.deadline}"
+    else task.deadline < Time.zone.today
+      "#{task.title}の期限は超過しています。期日:#{task.deadline}"
+    end
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  add_template_helper(TasksHelper)
+  default from: "taskel@test.com"
   layout 'mailer'
 end

--- a/app/mailers/task_mailer.rb
+++ b/app/mailers/task_mailer.rb
@@ -1,0 +1,8 @@
+class TaskMailer < ApplicationMailer
+  def send_deadline(user, tasks)
+    @user = user
+    @tasks = tasks
+    mail  to: user.email,
+          subject: 'タスクの期限が迫っています。'
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,6 +23,14 @@ class Task < ApplicationRecord
     self.not_completed_tasks.near_deadline_tasks
   end
 
+  def self.remind_tasks
+    users = User.all
+    users.each do |user|
+      remind_tasks = user.tasks.notice_tasks
+      TaskMailer.send_deadline(user, remind_tasks).deliver
+    end
+  end
+
   private
   def self.search_title(title)
     where('title Like(?)', "%#{title}%")

--- a/app/views/task_mailer/send_deadline.html.slim
+++ b/app/views/task_mailer/send_deadline.html.slim
@@ -1,0 +1,21 @@
+doctype html
+html lang="ja" 
+  head
+    meta content=("text/html; charset=UTF-8") http-equiv="Content-Type" /
+    meta content=("text/html; charset=UTF-8") /
+    css:
+      | h2 {
+        | color: #e7454a;
+      | }
+      | p hr {
+        | color: #2d2a24;
+      | }
+  body
+    h2
+      = @user.name
+      | 様
+    p
+      | 期限間近のタスクです。
+      - @tasks.each do |task|
+        p
+          = task_reminder(task)

--- a/app/views/task_mailer/send_deadline.text.erb
+++ b/app/views/task_mailer/send_deadline.text.erb
@@ -1,0 +1,6 @@
+<%= @user.name %> 様
+
+以下が期限間近のタスクです。
+<% @tasks.each do |task| %>
+  <%= task_reminder(task) %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module Taskel
 
     config.assets.precompile += %w[admin/active_admin.css admin/active_admin.js]
 
+    config.autoload_paths += Dir["#{config.root}/lib/tasks"]
+
     # config.autoload_paths += Dir[Rails.root.join('app', 'uploaders')]
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,4 +91,17 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    port:                 587,
+    address:              'smtp.sendgrid.net',
+    domain:               'heroku.com',
+    user_name:            ENV['SENDGRID_USERNAME'],
+    password:             ENV['SENDGRID_PASSWORD'],
+    authentication:       :plain,
+    enable_starttls_auto: true
+  }
 end

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -1,0 +1,6 @@
+namespace :reminder do
+  desc '日次リマインダーメール'
+  task task_reminder: :environment do
+    Task.remind_tasks
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/2375644/stories/167421371
詳細はこちらに記載。

メール通知のやり方ですが、rakeタスクを使ったメール通知設定のやり方で丁度良い記事が見つかったのでそちらを参考にしながら実装しました。
想定としては1日1回朝9時にリマインダーのメールが、登録者に飛びます。
リマインドされるタスクとしては、明日が期限のタスク、期限当日のタスク、期限超過のタスクの3種類です。

<img width="506" alt="スクリーンショット 2019-08-30 18 40 47" src="https://user-images.githubusercontent.com/17251348/64010990-bd4b5400-cb55-11e9-8c7d-ce951ba9915e.png">
